### PR TITLE
Auto Crawler 완성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,10 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // 웹 크롤링을 위해 추가한 라이브러리
+    implementation 'org.jsoup:jsoup:1.16.1'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ohlottery/OhLotteryApplication.java
+++ b/src/main/java/com/ohlottery/OhLotteryApplication.java
@@ -2,7 +2,9 @@ package com.ohlottery;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class OhLotteryApplication {
 

--- a/src/main/java/com/ohlottery/controller/Lottery645Controller.java
+++ b/src/main/java/com/ohlottery/controller/Lottery645Controller.java
@@ -54,21 +54,21 @@ public class Lottery645Controller {
         if (roundResult.isEmpty()) return ResponseEntity.notFound().build();
 
         Lottery645Entity resultEntity = roundResult.get();
-        Lottery645Dto resultDto = Lottery645Dto.builder()
-                .round(resultEntity.getRound())
-                .bonusNo(resultEntity.getBonusNo())
-                .drawDate(resultEntity.getDrawDate())
-                .drawNo1(resultEntity.getDrawNo1())
-                .drawNo2(resultEntity.getDrawNo2())
-                .drawNo3(resultEntity.getDrawNo3())
-                .drawNo4(resultEntity.getDrawNo4())
-                .drawNo5(resultEntity.getDrawNo5())
-                .drawNo6(resultEntity.getDrawNo6())
-                .firstAccumulateAmount(resultEntity.getFirstAccumulateAmount())
-                .firstPrizeWinnerCount(resultEntity.getFirstPrizeWinnerCount())
-                .totalSellAmount(resultEntity.getTotalSellAmount())
-                .firstWinAmount(resultEntity.getFirstWinAmount())
-                .build();
+        Lottery645Dto resultDto = new Lottery645Dto(
+                resultEntity.getRound(),
+                resultEntity.getDrawDate(),
+                resultEntity.getDrawNo1(),
+                resultEntity.getDrawNo2(),
+                resultEntity.getDrawNo3(),
+                resultEntity.getDrawNo4(),
+                resultEntity.getDrawNo5(),
+                resultEntity.getDrawNo6(),
+                resultEntity.getBonusNo(),
+                resultEntity.getFirstAccumulateAmount(),
+                resultEntity.getFirstPrizeWinnerCount(),
+                resultEntity.getFirstWinAmount(),
+                resultEntity.getTotalSellAmount()
+        );
         return ResponseEntity.ok(resultDto);
     }
 }

--- a/src/main/java/com/ohlottery/controller/Lottery720Controller.java
+++ b/src/main/java/com/ohlottery/controller/Lottery720Controller.java
@@ -48,13 +48,13 @@ public class Lottery720Controller {
         if (roundResult.isEmpty()) return ResponseEntity.notFound().build();
 
         Lottery720Entity resultEntity = roundResult.get();
-        Lottery720Dto resultDto = Lottery720Dto.builder()
-                .round(resultEntity.getRound())
-                .drawDate(resultEntity.getDrawDate())
-                .rankClass(resultEntity.getRankClass())
-                .rankNo(resultEntity.getRankNo())
-                .rankWinNum(resultEntity.getRankWinNum())
-                .build();
+        Lottery720Dto resultDto = new Lottery720Dto(
+                resultEntity.getRound(),
+                resultEntity.getDrawDate(),
+                resultEntity.getRankWinNum(),
+                resultEntity.getRankClass(),
+                resultEntity.getRankNo()
+        );
         return ResponseEntity.ok(resultDto);
     }
 

--- a/src/main/java/com/ohlottery/controller/LotteryCrawlerController.java
+++ b/src/main/java/com/ohlottery/controller/LotteryCrawlerController.java
@@ -1,0 +1,31 @@
+package com.ohlottery.controller;
+
+import com.ohlottery.service.DHLotteryCrawlerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.concurrent.CompletableFuture;
+
+@RestController
+@RequestMapping("/crawler")
+@RequiredArgsConstructor
+public class LotteryCrawlerController {
+
+    private final DHLotteryCrawlerService lotteryCrawlerService;
+
+    @PatchMapping("/lottery645/{round}")
+    public ResponseEntity<Void> fetchLottery645(@PathVariable long round) {
+        lotteryCrawlerService.fetchLottery645Data(round);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/lottery720/{round}")
+    public ResponseEntity<Void> fetchLottery720(@PathVariable long round) {
+        lotteryCrawlerService.fetchLottery720Data(round);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/ohlottery/controller/LotteryCrawlerController.java
+++ b/src/main/java/com/ohlottery/controller/LotteryCrawlerController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.concurrent.CompletableFuture;
+//Authentication 과정 필수로 필요
 
 @RestController
 @RequestMapping("/crawler")

--- a/src/main/java/com/ohlottery/dto/Lottery645Dto.java
+++ b/src/main/java/com/ohlottery/dto/Lottery645Dto.java
@@ -1,13 +1,13 @@
 package com.ohlottery.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import java.time.LocalDate;
 
 @Data
-@Builder
+@AllArgsConstructor
 @Schema(description = "6/45 로또 정보")
 public class Lottery645Dto {
 

--- a/src/main/java/com/ohlottery/dto/Lottery720Dto.java
+++ b/src/main/java/com/ohlottery/dto/Lottery720Dto.java
@@ -1,13 +1,13 @@
 package com.ohlottery.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import java.time.LocalDate;
 
 @Data
-@Builder
+@AllArgsConstructor
 @Schema(description = "연금복권 정보")
 public class Lottery720Dto {
 
@@ -18,7 +18,7 @@ public class Lottery720Dto {
     private LocalDate drawDate;
 
     @Schema(description = "등수", example = "1")
-    private short rankWinNum;
+    private int rankWinNum;
 
     @Schema(description = "당첨 조 번호", example = "4")
     private int rankClass;

--- a/src/main/java/com/ohlottery/entity/Lottery645Entity.java
+++ b/src/main/java/com/ohlottery/entity/Lottery645Entity.java
@@ -1,15 +1,19 @@
 package com.ohlottery.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Lottery645Entity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id // @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long round;
 
     private LocalDate drawDate;
@@ -29,4 +33,23 @@ public class Lottery645Entity {
     private long firstWinAmount;
     // 총 판매금액
     private long totalSellAmount;
+
+    @Builder
+    public Lottery645Entity(long round, LocalDate drawDate, byte drawNo1, byte drawNo2, byte drawNo3, byte drawNo4,
+                            byte drawNo5, byte drawNo6, byte bonusNo, long firstAccumulateAmount,
+                            long firstPrizeWinnerCount, long firstWinAmount, long totalSellAmount) {
+        this.round = round;
+        this.drawDate = drawDate;
+        this.drawNo1 = drawNo1;
+        this.drawNo2 = drawNo2;
+        this.drawNo3 = drawNo3;
+        this.drawNo4 = drawNo4;
+        this.drawNo5 = drawNo5;
+        this.drawNo6 = drawNo6;
+        this.bonusNo = bonusNo;
+        this.firstAccumulateAmount = firstAccumulateAmount;
+        this.firstPrizeWinnerCount = firstPrizeWinnerCount;
+        this.firstWinAmount = firstWinAmount;
+        this.totalSellAmount = totalSellAmount;
+    }
 }

--- a/src/main/java/com/ohlottery/entity/Lottery645Entity.java
+++ b/src/main/java/com/ohlottery/entity/Lottery645Entity.java
@@ -1,19 +1,17 @@
 package com.ohlottery.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 
 @Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@NoArgsConstructor
 public class Lottery645Entity {
 
-    @Id // @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
     private long round;
 
     private LocalDate drawDate;
@@ -33,23 +31,4 @@ public class Lottery645Entity {
     private long firstWinAmount;
     // 총 판매금액
     private long totalSellAmount;
-
-    @Builder
-    public Lottery645Entity(long round, LocalDate drawDate, byte drawNo1, byte drawNo2, byte drawNo3, byte drawNo4,
-                            byte drawNo5, byte drawNo6, byte bonusNo, long firstAccumulateAmount,
-                            long firstPrizeWinnerCount, long firstWinAmount, long totalSellAmount) {
-        this.round = round;
-        this.drawDate = drawDate;
-        this.drawNo1 = drawNo1;
-        this.drawNo2 = drawNo2;
-        this.drawNo3 = drawNo3;
-        this.drawNo4 = drawNo4;
-        this.drawNo5 = drawNo5;
-        this.drawNo6 = drawNo6;
-        this.bonusNo = bonusNo;
-        this.firstAccumulateAmount = firstAccumulateAmount;
-        this.firstPrizeWinnerCount = firstPrizeWinnerCount;
-        this.firstWinAmount = firstWinAmount;
-        this.totalSellAmount = totalSellAmount;
-    }
 }

--- a/src/main/java/com/ohlottery/entity/Lottery720Entity.java
+++ b/src/main/java/com/ohlottery/entity/Lottery720Entity.java
@@ -1,19 +1,17 @@
 package com.ohlottery.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 
 @Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@NoArgsConstructor
 public class Lottery720Entity {
 
-    @Id // @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
     private long round;// 회차
 
     private LocalDate drawDate;// 추첨 날짜
@@ -21,13 +19,4 @@ public class Lottery720Entity {
     private short rankWinNum;// 등수
     private byte rankClass;// 조 번호
     private int rankNo;// 당첨 번호
-
-    @Builder
-    public Lottery720Entity(long round, LocalDate drawDate, short rankWinNum, byte rankClass, int rankNo) {
-        this.round = round;
-        this.drawDate = drawDate;
-        this.rankWinNum = rankWinNum;
-        this.rankClass = rankClass;
-        this.rankNo = rankNo;
-    }
 }

--- a/src/main/java/com/ohlottery/entity/Lottery720Entity.java
+++ b/src/main/java/com/ohlottery/entity/Lottery720Entity.java
@@ -16,7 +16,7 @@ public class Lottery720Entity {
 
     private LocalDate drawDate;// 추첨 날짜
 
-    private short rankWinNum;// 등수
+    private byte rankWinNum;// 등수
     private byte rankClass;// 조 번호
     private int rankNo;// 당첨 번호
 }

--- a/src/main/java/com/ohlottery/entity/Lottery720Entity.java
+++ b/src/main/java/com/ohlottery/entity/Lottery720Entity.java
@@ -1,15 +1,19 @@
 package com.ohlottery.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Lottery720Entity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id // @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long round;// 회차
 
     private LocalDate drawDate;// 추첨 날짜
@@ -17,4 +21,13 @@ public class Lottery720Entity {
     private short rankWinNum;// 등수
     private byte rankClass;// 조 번호
     private int rankNo;// 당첨 번호
+
+    @Builder
+    public Lottery720Entity(long round, LocalDate drawDate, short rankWinNum, byte rankClass, int rankNo) {
+        this.round = round;
+        this.drawDate = drawDate;
+        this.rankWinNum = rankWinNum;
+        this.rankClass = rankClass;
+        this.rankNo = rankNo;
+    }
 }

--- a/src/main/java/com/ohlottery/repository/Lottery645Repository.java
+++ b/src/main/java/com/ohlottery/repository/Lottery645Repository.java
@@ -2,8 +2,14 @@ package com.ohlottery.repository;
 
 import com.ohlottery.entity.Lottery645Entity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface Lottery645Repository extends JpaRepository<Lottery645Entity, Long> {
+    boolean existsByRound(long round);
+
+    @Query("SELECT COALESCE(MAX(l.round), 0) FROM Lottery645Entity l")
+    int findMaxRound();
+
 }

--- a/src/main/java/com/ohlottery/repository/Lottery645Repository.java
+++ b/src/main/java/com/ohlottery/repository/Lottery645Repository.java
@@ -7,8 +7,9 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface Lottery645Repository extends JpaRepository<Lottery645Entity, Long> {
+    
     boolean existsByRound(long round);
-
+    
     @Query("SELECT COALESCE(MAX(l.round), 0) FROM Lottery645Entity l")
     int findMaxRound();
 

--- a/src/main/java/com/ohlottery/repository/Lottery720Repository.java
+++ b/src/main/java/com/ohlottery/repository/Lottery720Repository.java
@@ -2,8 +2,13 @@ package com.ohlottery.repository;
 
 import com.ohlottery.entity.Lottery720Entity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface Lottery720Repository extends JpaRepository<Lottery720Entity, Long> {
+    boolean existsByRound(long round);
+    @Query("SELECT COALESCE(MAX(l.round), 0) FROM Lottery720Entity l")
+    int findMaxRound();
+
 }

--- a/src/main/java/com/ohlottery/scheduler/LotteryCrawlerScheduler.java
+++ b/src/main/java/com/ohlottery/scheduler/LotteryCrawlerScheduler.java
@@ -1,0 +1,85 @@
+package com.ohlottery.scheduler;
+
+import com.ohlottery.service.DHLotteryCrawlerService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LotteryCrawlerScheduler {
+
+    private final DHLotteryCrawlerService lotteryCrawlerService;
+
+    @Scheduled(cron = "0 35 20 * * 6") // 매주 토요일 20:35
+    public void scheduleFetchLottery645Data() {
+        log.info("Scheduled Task: fetchLottery645Data 실행 중");
+        try {
+            int latestRound = getLatestLottery645Round();
+            log.info("가져온 최신 6/45 로또 회차: {}", latestRound);
+            scheduleRetryFetch(() -> lotteryCrawlerService.fetchLottery645Data(latestRound), "6/45", latestRound);
+        } catch (Exception e) {
+            log.error("fetchLottery645Data 실행 중 에러 발생", e);
+        }
+    }
+
+    @Scheduled(cron = "0 5 19 * * 4") // 매주 목요일 19:05
+    public void scheduleFetchLottery720Data() {
+        log.info("Scheduled Task: fetchLottery720Data 실행 중");
+        try {
+            int latestRound = getLatestLottery720Round();
+            log.info("가져온 최신 720 로또 회차: {}", latestRound);
+            scheduleRetryFetch(() -> lotteryCrawlerService.fetchLottery720Data(latestRound), "720", latestRound);
+        } catch (Exception e) {
+            log.error("fetchLottery720Data 실행 중 에러 발생", e);
+        }
+    }
+
+    private void scheduleRetryFetch(Runnable fetchTask, String lotteryType, int round) {
+        ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+        final int[] retryCount = {0}; // 재시도 횟수
+        final int maxRetries = 12; // 최대 12번 재시도 (5분 x 12 = 1시간)
+
+        executor.scheduleAtFixedRate(() -> {
+            try {
+                log.info("재시도 실행 중: {} 로또 회차 {} | 시도 횟수: {}/{}", lotteryType, round, retryCount[0] + 1, maxRetries);
+                fetchTask.run();
+                log.info("재시도 성공: {} 로또 회차 {}", lotteryType, round);
+                executor.shutdown(); // 성공하면 재시도 종료
+            } catch (Exception e) {
+                retryCount[0]++;
+                log.error("재시도 실패: {} 로또 회차 {} | 시도 횟수: {}/{}", lotteryType, round, retryCount[0], maxRetries, e);
+                if (retryCount[0] >= maxRetries) {
+                    log.error("재시도 횟수 초과로 중단: {} 로또 회차 {}", lotteryType, round);
+                    executor.shutdown(); // 최대 재시도 횟수 초과 시 종료
+                }
+            }
+        }, 0, 5, TimeUnit.MINUTES); // 즉시 실행, 이후 5분 간격
+    }
+
+    private int getLatestLottery645Round() {
+        try {
+            int latestRound = lotteryCrawlerService.getLatest645Round();
+            return latestRound + 1;
+        } catch (Exception e) {
+            log.error("6/45 최신 회차를 가져오는 중 에러 발생", e);
+            return -1;
+        }
+    }
+
+    private int getLatestLottery720Round() {
+        try {
+            int latestRound = lotteryCrawlerService.getLatest720Round();
+            return latestRound + 1;
+        } catch (Exception e) {
+            log.error("720 최신 회차를 가져오는 중 에러 발생", e);
+            return -1;
+        }
+    }
+}

--- a/src/main/java/com/ohlottery/service/DHLotteryCrawlerService.java
+++ b/src/main/java/com/ohlottery/service/DHLotteryCrawlerService.java
@@ -1,23 +1,250 @@
 package com.ohlottery.service;
 
+import com.ohlottery.dto.Lottery645Dto;
+import com.ohlottery.dto.Lottery720Dto;
+import com.ohlottery.entity.Lottery645Entity;
+import com.ohlottery.entity.Lottery720Entity;
 import com.ohlottery.repository.Lottery645Repository;
 import com.ohlottery.repository.Lottery720Repository;
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
+@Slf4j
+@Builder
 @RequiredArgsConstructor
 public class DHLotteryCrawlerService {
 
     private final Lottery645Repository lottery645Repository;
     private final Lottery720Repository lottery720Repository;
 
-    public void fetchLottery645Data(int round){
+    @Transactional
+    public void fetchLottery645Data(long round) {
+        log.info("fetchLottery645Data 실행 : {}", round);
 
+        if (lottery645Repository.existsByRound(round)) {
+            log.warn("{}회차 데이터가 이미 존재함 - 저장 생략!", round);
+            return;
+        }
+
+        try {
+            Lottery645Dto dto = crawlLottery645Data(round);
+            Lottery645Entity entity = convertToEntity(dto);
+            lottery645Repository.save(entity);
+            log.info("{}회차 데이터 저장 완료!", round);
+
+        } catch (Exception e) {
+            log.error("{}회차 데이터 저장 중 에러 발생: {}", round, e.getMessage(), e);
+        }
     }
 
-    public void fetchLottery720Data(int round){
+    private Lottery645Dto crawlLottery645Data(long round) throws Exception {
+        log.info("crawlLottery645Data 실행 : {}", round);
+        String url = "https://dhlottery.co.kr/gameResult.do?method=byWin&drwNo=" + round;
+        log.info("URL과 연결 중 : {}", url);
 
+        Document document = Jsoup.connect(url).get();
+        log.info("성공적으로 URL과 연결 및 HTML 파싱 완료");
+
+        // 추첨일자 파싱
+        Element drawDateElement = document.selectFirst("div.win_result > p.desc");
+        if (drawDateElement == null) {
+            log.error("drawDateElement를 찾을 수 없습니다. HTML 구조를 확인하세요. 회차: {}", round);
+            throw new IllegalArgumentException("부적합한 HTML 구조");
+        }
+        String drawDateText = drawDateElement.text(); // ex) (2024년 11월 30일 추첨)
+
+        LocalDate drawDate = LocalDate.parse(
+                drawDateText.replace("(", "").replace(" 추첨)", ""),
+                DateTimeFormatter.ofPattern("yyyy년 MM월 dd일")
+        );
+        log.info("파싱된 drawDate: {}", drawDate);
+
+        Elements numberElements = document.select(".ball_645");
+        if (numberElements.size() < 7) {
+            log.error("당첨 번호가 충분하지 않습니다. HTML 구조를 확인하세요.");
+            throw new IllegalArgumentException("당첨번호 개수 부족");
+        }
+
+        int drawNo1 = Integer.parseInt(numberElements.get(0).text());
+        int drawNo2 = Integer.parseInt(numberElements.get(1).text());
+        int drawNo3 = Integer.parseInt(numberElements.get(2).text());
+        int drawNo4 = Integer.parseInt(numberElements.get(3).text());
+        int drawNo5 = Integer.parseInt(numberElements.get(4).text());
+        int drawNo6 = Integer.parseInt(numberElements.get(5).text());
+        int bonusNo = Integer.parseInt(numberElements.get(6).text());
+
+        log.info("당첨 번호: [{}, {}, {}, {}, {}, {}], 보너스 번호: {}", drawNo1, drawNo2, drawNo3, drawNo4, drawNo5, drawNo6, bonusNo);
+
+        // 당첨금 데이터 추출
+        Elements prizeElements = document.select(".tbl_data tbody tr");
+        if (prizeElements.isEmpty()) {
+            log.error("당첨금 데이터를 찾을 수 없습니다.");
+            throw new IllegalArgumentException("당첨금 데이터 실종");
+        }
+
+        long firstAccumulateAmount = parseLongOrDefault(
+                prizeElements.get(0).select("td").get(1).text(), 0L);
+        long firstPrizeWinnerCount = parseLongOrDefault(
+                prizeElements.get(0).select("td").get(2).text(), 0L);
+        long firstWinAmount = parseLongOrDefault(
+                prizeElements.get(0).select("td").get(3).text(), 0L);
+        long totalSellAmount = parseLongOrDefault(
+                document.select(".total strong").text(), 0L);
+        log.info("1등 관련 자료 파싱 완료");
+
+        return Lottery645Dto.builder()
+                .round(round)
+                .drawDate(drawDate)
+                .drawNo1(drawNo1)
+                .drawNo2(drawNo2)
+                .drawNo3(drawNo3)
+                .drawNo4(drawNo4)
+                .drawNo5(drawNo5)
+                .drawNo6(drawNo6)
+                .bonusNo(bonusNo)
+                .firstAccumulateAmount(firstAccumulateAmount)
+                .firstPrizeWinnerCount(firstPrizeWinnerCount)
+                .firstWinAmount(firstWinAmount)
+                .totalSellAmount(totalSellAmount)
+                .build();
+    }
+
+    private Lottery645Entity convertToEntity(Lottery645Dto dto) {
+        return Lottery645Entity.builder()
+                .round(dto.getRound())
+                .drawDate(dto.getDrawDate())
+                .drawNo1((byte) dto.getDrawNo1())
+                .drawNo2((byte) dto.getDrawNo2())
+                .drawNo3((byte) dto.getDrawNo3())
+                .drawNo4((byte) dto.getDrawNo4())
+                .drawNo5((byte) dto.getDrawNo5())
+                .drawNo6((byte) dto.getDrawNo6())
+                .bonusNo((byte) dto.getBonusNo())
+                .firstAccumulateAmount(dto.getFirstAccumulateAmount())
+                .firstPrizeWinnerCount(dto.getFirstPrizeWinnerCount())
+                .firstWinAmount(dto.getFirstWinAmount())
+                .totalSellAmount(dto.getTotalSellAmount())
+                .build();
+    }
+
+    private long parseLongOrDefault(String input, long defaultValue) {
+        try {
+            return Long.parseLong(input.replaceAll("[^0-9]", ""));
+        } catch (NumberFormatException e) {
+            log.warn("숫자 변환 실패, 기본값 반환: '{}', 입력 값: '{}'", defaultValue, input);
+            return defaultValue;
+        }
+    }
+
+    public int getLatest645Round() {
+        return lottery645Repository.findMaxRound();
+    }
+
+    @Transactional
+    public void fetchLottery720Data(long round) {
+        log.info("fetchLottery720Data 실행 : {}", round);
+
+        if (lottery720Repository.existsByRound(round)) {
+            log.warn("해당 회차 {} 데이터가 이미 존재함 - 저장 생략!", round);
+            return;
+        }
+
+        try {
+            Lottery720Dto dto = crawlLottery720Data(round); // DTO 생성
+            Lottery720Entity entity = convertToEntityUsingBuilder(dto); // DTO를 Entity로 변환
+            lottery720Repository.save(entity); // 엔티티 저장
+            log.info("회차 {} 데이터 저장 완료.", round);
+
+        } catch (Exception e) {
+            log.error("해당 회차에 대한 데이터 저장 중 에러 발생: {}", round, e);
+        }
+    }
+
+
+    private Lottery720Dto crawlLottery720Data(long round) throws Exception {
+        log.info("crawlLottery720Data 실행 : {}", round);
+        String url = "https://dhlottery.co.kr/gameResult.do?method=win720&drwNo=" + round;
+        log.info("URL과 연결 중 : {}", url);
+
+        Document document = Jsoup.connect(url).get();
+        log.info("성공적으로 URL과 연결 및 HTML 파싱 완료");
+
+        // 추첨일자 파싱
+        Element drawDateElement = document.selectFirst("div.win_result > p.desc");
+        if (drawDateElement == null) {
+            log.error("drawDateElement를 찾을 수 없습니다. HTML 구조를 확인하세요. 회차: {}", round);
+            throw new IllegalArgumentException("부적합한 HTML 구조");
+        }
+
+        String drawDateText = drawDateElement.text(); // ex) (2024년 12월 05일 추첨)
+        LocalDate drawDate = LocalDate.parse(
+                drawDateText.replace("(", "").replace(" 추첨)", ""),
+                DateTimeFormatter.ofPattern("yyyy년 MM월 dd일")
+        );
+
+        log.info("파싱된 drawDate: {}", drawDate);
+
+        // 당첨 데이터 파싱
+        Elements prizeElements = document.select(".tbl_data tbody tr");
+        if (prizeElements.isEmpty()) {
+            log.error("당첨 데이터가 비어 있습니다. HTML 구조를 확인하세요.");
+            throw new IllegalArgumentException("당첨 데이터 부족");
+        }
+
+        Element firstRow = prizeElements.get(0);
+        int rankWinNum = parseIntOrDefault(firstRow.select("td").get(0).text(), -1);
+        int rankClass = parseIntOrDefault(firstRow.select("td").get(1).text(), -1);
+        int rankNo = parseIntOrDefault(firstRow.select("td").get(2).text(), -1);
+
+        if (rankWinNum == -1 || rankClass == -1 || rankNo == -1) {
+            throw new IllegalArgumentException("당첨 데이터에 숫자로 변환할 수 없는 값이 포함되어 있습니다.");
+        }
+
+        return Lottery720Dto.builder()
+                .round(round)
+                .drawDate(drawDate)
+                .rankWinNum((short) rankWinNum)
+                .rankClass((byte) rankClass)
+                .rankNo(rankNo)
+                .build();
+    }
+
+    private Lottery720Entity convertToEntityUsingBuilder(Lottery720Dto dto) {
+        return Lottery720Entity.builder()
+                .round(dto.getRound())
+                .drawDate(dto.getDrawDate())
+                .rankWinNum(dto.getRankWinNum())
+                .rankClass((byte) dto.getRankClass())
+                .rankNo(dto.getRankNo())
+                .build();
+    }
+
+    private int parseIntOrDefault(String input, int defaultValue) {
+        try {
+            String numericValue = input.replaceAll("[^0-9]", "");
+            return Integer.parseInt(numericValue);
+        } catch (NumberFormatException e) {
+            log.warn("문자열을 숫자로 변환하지 못했습니다. 기본값 반환: '{}', 원본 값: '{}'", defaultValue, input, e);
+            return defaultValue;
+        }
+    }
+
+    public int getLatest720Round() {
+        return lottery720Repository.findMaxRound();
     }
 
     /* TODO

--- a/src/main/java/com/ohlottery/service/DHLotteryCrawlerService.java
+++ b/src/main/java/com/ohlottery/service/DHLotteryCrawlerService.java
@@ -6,7 +6,6 @@ import com.ohlottery.entity.Lottery645Entity;
 import com.ohlottery.entity.Lottery720Entity;
 import com.ohlottery.repository.Lottery645Repository;
 import com.ohlottery.repository.Lottery720Repository;
-import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
@@ -21,7 +20,6 @@ import java.time.format.DateTimeFormatter;
 
 @Service
 @Slf4j
-@Builder
 @RequiredArgsConstructor
 public class DHLotteryCrawlerService {
 
@@ -103,21 +101,8 @@ public class DHLotteryCrawlerService {
                 document.select(".total strong").text(), 0L);
         log.info("1등 관련 자료 파싱 완료");
 
-        return Lottery645Dto.builder()
-                .round(round)
-                .drawDate(drawDate)
-                .drawNo1(drawNo1)
-                .drawNo2(drawNo2)
-                .drawNo3(drawNo3)
-                .drawNo4(drawNo4)
-                .drawNo5(drawNo5)
-                .drawNo6(drawNo6)
-                .bonusNo(bonusNo)
-                .firstAccumulateAmount(firstAccumulateAmount)
-                .firstPrizeWinnerCount(firstPrizeWinnerCount)
-                .firstWinAmount(firstWinAmount)
-                .totalSellAmount(totalSellAmount)
-                .build();
+        return new Lottery645Dto(round, drawDate, drawNo1, drawNo2, drawNo3, drawNo4, drawNo5, drawNo6, bonusNo,
+                firstAccumulateAmount, firstPrizeWinnerCount, firstWinAmount, totalSellAmount);
     }
 
     private Lottery645Entity convertToEntity(Lottery645Dto dto) {
@@ -210,20 +195,14 @@ public class DHLotteryCrawlerService {
             throw new IllegalArgumentException("당첨 데이터에 숫자로 변환할 수 없는 값이 포함되어 있습니다.");
         }
 
-        return Lottery720Dto.builder()
-                .round(round)
-                .drawDate(drawDate)
-                .rankWinNum((short) rankWinNum)
-                .rankClass((byte) rankClass)
-                .rankNo(rankNo)
-                .build();
+        return new Lottery720Dto(round, drawDate, (short) rankWinNum, (byte) rankClass, rankNo);
     }
 
     private Lottery720Entity convertToEntityUsingBuilder(Lottery720Dto dto) {
         return new Lottery720Entity(
                 dto.getRound(),
                 dto.getDrawDate(),
-                dto.getRankWinNum(),
+                (byte) dto.getRankWinNum(),
                 (byte) dto.getRankClass(),
                 dto.getRankNo()
         );

--- a/src/main/java/com/ohlottery/service/DHLotteryCrawlerService.java
+++ b/src/main/java/com/ohlottery/service/DHLotteryCrawlerService.java
@@ -18,9 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
-import java.util.ArrayList;
-import java.util.List;
 
 @Service
 @Slf4j
@@ -124,21 +121,20 @@ public class DHLotteryCrawlerService {
     }
 
     private Lottery645Entity convertToEntity(Lottery645Dto dto) {
-        return Lottery645Entity.builder()
-                .round(dto.getRound())
-                .drawDate(dto.getDrawDate())
-                .drawNo1((byte) dto.getDrawNo1())
-                .drawNo2((byte) dto.getDrawNo2())
-                .drawNo3((byte) dto.getDrawNo3())
-                .drawNo4((byte) dto.getDrawNo4())
-                .drawNo5((byte) dto.getDrawNo5())
-                .drawNo6((byte) dto.getDrawNo6())
-                .bonusNo((byte) dto.getBonusNo())
-                .firstAccumulateAmount(dto.getFirstAccumulateAmount())
-                .firstPrizeWinnerCount(dto.getFirstPrizeWinnerCount())
-                .firstWinAmount(dto.getFirstWinAmount())
-                .totalSellAmount(dto.getTotalSellAmount())
-                .build();
+        return new Lottery645Entity(
+                dto.getRound(),
+                dto.getDrawDate(),
+                (byte) dto.getDrawNo1(),
+                (byte) dto.getDrawNo2(),
+                (byte) dto.getDrawNo3(),
+                (byte) dto.getDrawNo4(),
+                (byte) dto.getDrawNo5(),
+                (byte) dto.getDrawNo6(),
+                (byte) dto.getBonusNo(),
+                dto.getFirstAccumulateAmount(),
+                dto.getFirstPrizeWinnerCount(),
+                dto.getFirstWinAmount(),
+                dto.getTotalSellAmount());
     }
 
     private long parseLongOrDefault(String input, long defaultValue) {
@@ -224,13 +220,13 @@ public class DHLotteryCrawlerService {
     }
 
     private Lottery720Entity convertToEntityUsingBuilder(Lottery720Dto dto) {
-        return Lottery720Entity.builder()
-                .round(dto.getRound())
-                .drawDate(dto.getDrawDate())
-                .rankWinNum(dto.getRankWinNum())
-                .rankClass((byte) dto.getRankClass())
-                .rankNo(dto.getRankNo())
-                .build();
+        return new Lottery720Entity(
+                dto.getRound(),
+                dto.getDrawDate(),
+                dto.getRankWinNum(),
+                (byte) dto.getRankClass(),
+                dto.getRankNo()
+        );
     }
 
     private int parseIntOrDefault(String input, int defaultValue) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/ohlottery
     username: root
-    password:
+    password: kimhy119@
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:


### PR DESCRIPTION
@SalkCoding 

<Entity 변경사항>
1. DHLotteryCrawlerService 내부에서 dto를 이용해 파싱한 데이터들을 엔티티로 변환 후 DB에 저장하는 기능을 위해 "@NoArgsConstructor(access = AccessLevel.PROTECTED)"를 선언하고 DHLotteryCrawlerService에서 객체를 생성 및 변환하는 데 사용하기 위해 "@Builder"를 사용해서 생성자를 만들었습니다.

2. "private long round;"에 있는 "@GeneratedValue(strategy = GenerationType.IDENTITY)"를 그대로 두면 계속 오류가 나고 잠시 지우면 오류가 나지 않아 문서랑 구글링을 좀 해봤습니다. 해당 어노테이션은 DB에서 자동으로 기본 키 값을 생성하도록 설정하는 것인데, 원래라면 충돌이 나지 않지만 저희는 round를 Id로 설정해서 문제가 생기는 것 같습니다. 왜냐하면 제가 크롤링해오는 것 중에 round 값도 있는데 이미 제가 사이트에서 round(Id)를 크롤링해서 그걸 DB에 넣게 되고 그러면 이미 Id가 존재하는데 이때 예외가 발생해서 오류가 난다고 합니다.
 그 해결책으로는 "@GeneratedValue(strategy = GenerationType.AUTO)"가 있다고는 하는데 해당 방법은 별로 권장되지 않는다고 하여 일단 "@GeneratedValue(strategy = GenerationType.IDENTITY)"를 제거하는 방향으로 가려고 하는데 괜찮을까요..? 테스트해보니 이게 DB에 저장할때 회차 순으로 오름차순되서 정렬되더라구요. 그래서 6/45는 1149회차, 720+는 240회차인 상황에서 저희가 이전 회차의 데이터들을 미리 데이터를 넣기로 했으니 "@GeneratedValue(strategy = GenerationType.IDENTITY)"를 ㅈ...제거해도 ㄱ...괜찮을 것 같다고 생각하는데 상범님의 의견 편하게 들려주시면 감사하겠습니다!

3. <Repository 변경사항 3&4> - "boolean existsByRound(long round);" = DHLotteryCrawlerService에서 이미 존재하는지 검사하기 위해 사용했습니다.

4. @Query("SELECT COALESCE(MAX(l.round), 0) FROM Lottery720Entity l")
    int findMaxRound();
    => LotteryCrawlerScheduler에서 현재 DB에 있는 데이터가 최신 데이터인지 검사하기 위해 사용했습니다.

5. <Service 변경사항> - DHLotteryCrawlerService 완성 : 해당 Service에 있는 fetchLottery645Data와 fetchLottery720Data, 그리고 나머지 메서드들은 해당 웹사이트에 연결 후 ??회차에 대한 모든 정보를 크롤링하도록 설계했습니다.

6. <Scheduler 변경사항> - DHLotteryCrawlerService를 이용해서 6/45는 매주 토요일 20:35 / 720+는 매주 목요일 19:05에 크롤링하도록 설계했으며 2개의 자동 크롤링 기능들 모두 만약 해당 웹사이트에 해당 주차의 복권 정보가 안 올라오면 5분 주기로 총 1시간동안 재 크롤링하도록 설계했습니다.

7.  <ohLotteryApplication 변경사항> - "@EnableScheduling" 추가 : 스케쥴링 기능을 사용하기 위해 추가했습니다.

8. <Controller 변경사항> - LotteryCrawlerController는 일종의 관리자 기능으로 만약 “LotteryCrawlerScheduler”에서의 자동 크롤링 기능에 문제가 생길 시 관리자가 수동으로 크롤링 기능 실행 후 DB에 저장할 수 있도록 했습니다.